### PR TITLE
Add support for Reveal API

### DIFF
--- a/lib/ex_clearbit/model.ex
+++ b/lib/ex_clearbit/model.ex
@@ -127,3 +127,28 @@ defmodule ExClearbit.Model.Prospector.Results do
   }
   use ExConstructor
 end
+
+defmodule ExClearbit.Model.Reveal do
+  @moduledoc """
+  Struct for company retrieved by the Reveal API
+  """
+  @derive [Poison.Encoder]
+  defstruct [
+    :ip,
+    :fuzzy,
+    :domain,
+    :type,
+    :company,
+    :geo_ip,
+  ]
+
+  @type t :: %__MODULE__{
+    ip: binary,
+    fuzzy: boolean,
+    domain: binary | nil,
+    type: binary,
+    geo_ip: map,
+    company: ExClearbit.Model.Company.t | nil,
+  }
+  use ExConstructor
+end


### PR DESCRIPTION
This PR adds support for [Clearbit's Reveal API](https://clearbit.com/docs#reveal-api). You can try it out with bunch of different IPs to see different responses:

```elixir
ExClearbit.reveal_ip("1.1.1.1")
```

 - 1.1.1.1
 - 80.231.135.141
 - 195.219.11.17
 - 195.219.118.185
 - 1.2.3.4
 - a.b.c.d

(Find more ASN IPs [here](https://dnslytics.com/bgp/as6453))